### PR TITLE
Proposal to rename to Envoy mech body

### DIFF
--- a/items/generic/mechparts/body/iwrmp_mechbodyenvoy.item
+++ b/items/generic/mechparts/body/iwrmp_mechbodyenvoy.item
@@ -8,7 +8,7 @@
   "builder" : "/items/buildscripts/buildmechpart.lua",
   "inventoryIcon" : "iwrmp_mechbodyenvoy.png",
   "description" : "A resilient mech body, able to withstand any enviroment ever!",
-  "shortdescription" : "Globetrotter Mech Body",
+  "shortdescription" : "Envoy Mech Body",
   "itemTags" : [ ],
 
   "mechPart" : ["body", "iwrmp_envoy"]


### PR DESCRIPTION
Feels both more direct to the point and more fitting than calling it globetrotter (especially for a vehicle geared more towards space exploration lol)